### PR TITLE
added metadata to Cargo.toml in order to release to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "multi-party-eddsa"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     "Omer <omer@kzencorp.com>",
     "Gary <gary@kzencorp.com>"
 ]
+license = "MIT"
+description = "Rust implementation of multiparty Ed25519 signature scheme."
+repository = "https://github.com/ZenGo-X/curv"
 
 [lib]
 crate-type = ["rlib", "dylib"]


### PR DESCRIPTION
The repository has yet to be uploaded to crates.io . I added metadata as seen in our curv library to the Cargo.toml file.
After this is merged I will add a new release and upload the repo.