### PR TITLE
serialize some struct and pub some field

### DIFF
--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -31,13 +31,13 @@ pub mod thresholdsig;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExpandedPrivateKey {
     pub prefix: Scalar<Ed25519>,
-    private_key: Scalar<Ed25519>,
+    pub private_key: Scalar<Ed25519>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExpandedKeyPair {
     pub public_key: Point<Ed25519>,
-    expanded_private_key: ExpandedPrivateKey,
+    pub expanded_private_key: ExpandedPrivateKey,
 }
 
 impl ExpandedKeyPair {

--- a/src/protocols/thresholdsig/mod.rs
+++ b/src/protocols/thresholdsig/mod.rs
@@ -31,6 +31,7 @@ pub struct Keys {
     pub party_index: u16,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct KeyGenBroadcastMessage1 {
     com: BigInt,
 }

--- a/src/protocols/thresholdsig/mod.rs
+++ b/src/protocols/thresholdsig/mod.rs
@@ -47,7 +47,7 @@ pub struct SharedKeys {
     pub x_i: Scalar<Ed25519>,
     prefix: Scalar<Ed25519>,
 }
-
+#[derive(Clone, Serialize, Deserialize)]
 pub struct EphemeralKey {
     pub r_i: Scalar<Ed25519>,
     pub R_i: Point<Ed25519>,

--- a/src/protocols/thresholdsig/mod.rs
+++ b/src/protocols/thresholdsig/mod.rs
@@ -60,6 +60,7 @@ pub struct EphemeralSharedKeys {
     pub r_i: Scalar<Ed25519>,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct LocalSig {
     gamma_i: Scalar<Ed25519>,
     k: Scalar<Ed25519>,

--- a/src/protocols/thresholdsig/mod.rs
+++ b/src/protocols/thresholdsig/mod.rs
@@ -47,7 +47,7 @@ pub struct SharedKeys {
     pub x_i: Scalar<Ed25519>,
     prefix: Scalar<Ed25519>,
 }
-#[derive(Clone, Serialize, Deserialize)]
+
 pub struct EphemeralKey {
     pub r_i: Scalar<Ed25519>,
     pub R_i: Point<Ed25519>,


### PR DESCRIPTION
1. Add serialize and deserialize derive for `KeyGenBroadcastMessage1` and `LocalSig`.  These messages may exchange with other parties via like json through http;
2. Make `private_key` public. We may need it when using `Diffi-hellman` to communicate with each other;